### PR TITLE
style(client): Aplicar diseño Boldo al sistema de Home Banking

### DIFF
--- a/client/src/app/features/auth/login/login.component.ts
+++ b/client/src/app/features/auth/login/login.component.ts
@@ -122,7 +122,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       align-items: center;
       justify-content: center;
       padding: 24px;
-      background: linear-gradient(135deg, #E3F2FD 0%, #BBDEFB 50%, #E8EAF6 100%);
+      background: linear-gradient(135deg, #0A2640 0%, #1A4A6D 100%);
     }
 
     .auth-brand {
@@ -134,19 +134,19 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       font-size: 48px;
       width: 48px;
       height: 48px;
-      color: #1976D2;
+      color: #65E4A3;
     }
 
     .auth-brand__name {
       font-size: 2rem;
       font-weight: 700;
-      color: #1565C0;
+      color: #ffffff;
       margin: 8px 0 4px;
       letter-spacing: -1px;
     }
 
     .auth-brand__tagline {
-      color: #616161;
+      color: rgba(255,255,255,0.7);
       font-size: 0.9375rem;
       margin: 0;
     }
@@ -154,7 +154,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
     .auth-card {
       width: 100%;
       max-width: 420px;
-      border-radius: 20px !important;
+      border-radius: 0.5rem !important;
       padding: 8px 16px 16px;
     }
 
@@ -164,8 +164,8 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       gap: 8px;
       padding: 12px 16px;
       border-radius: 8px;
-      background: rgba(211, 47, 47, 0.08);
-      color: #C62828;
+      background: rgba(220,53,69,0.1);
+      color: #DC3545;
       margin-bottom: 16px;
       font-size: 0.875rem;
     }
@@ -181,7 +181,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       font-size: 1rem;
       font-weight: 600;
       margin-top: 8px;
-      border-radius: 12px !important;
+      border-radius: 5rem !important;
     }
 
     .btn-spinner {
@@ -191,7 +191,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
 
     .auth-link-text {
       font-size: 0.875rem;
-      color: #757575;
+      color: #76979E;
       margin-right: 4px;
     }
 
@@ -201,14 +201,14 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       gap: 6px;
       margin-top: 24px;
       font-size: 0.8125rem;
-      color: #757575;
+      color: rgba(255,255,255,0.5);
     }
 
     .auth-footer__icon {
       font-size: 16px;
       width: 16px;
       height: 16px;
-      color: #43A047;
+      color: #65E4A3;
     }
   `]
 })

--- a/client/src/app/features/auth/register/register.component.ts
+++ b/client/src/app/features/auth/register/register.component.ts
@@ -179,7 +179,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       align-items: center;
       justify-content: center;
       padding: 24px;
-      background: linear-gradient(135deg, #E3F2FD 0%, #BBDEFB 50%, #E8EAF6 100%);
+      background: linear-gradient(135deg, #0A2640 0%, #1A4A6D 100%);
     }
 
     .auth-brand {
@@ -191,19 +191,19 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       font-size: 48px;
       width: 48px;
       height: 48px;
-      color: #1976D2;
+      color: #65E4A3;
     }
 
     .auth-brand__name {
       font-size: 2rem;
       font-weight: 700;
-      color: #1565C0;
+      color: #ffffff;
       margin: 8px 0 4px;
       letter-spacing: -1px;
     }
 
     .auth-brand__tagline {
-      color: #616161;
+      color: rgba(255,255,255,0.7);
       font-size: 0.9375rem;
       margin: 0;
     }
@@ -211,7 +211,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
     .auth-card {
       width: 100%;
       max-width: 480px;
-      border-radius: 20px !important;
+      border-radius: 0.5rem !important;
       padding: 8px 16px 16px;
     }
 
@@ -221,8 +221,8 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       gap: 8px;
       padding: 12px 16px;
       border-radius: 8px;
-      background: rgba(211, 47, 47, 0.08);
-      color: #C62828;
+      background: rgba(220,53,69,0.1);
+      color: #DC3545;
       margin-bottom: 16px;
       font-size: 0.875rem;
     }
@@ -263,9 +263,9 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       transition: all 300ms ease;
     }
 
-    .password-strength__bar--weak { width: 33%; background: #D32F2F; }
-    .password-strength__bar--medium { width: 66%; background: #FB8C00; }
-    .password-strength__bar--strong { width: 100%; background: #43A047; }
+    .password-strength__bar--weak { width: 33%; background: #DC3545; }
+    .password-strength__bar--medium { width: 66%; background: #FD7E14; }
+    .password-strength__bar--strong { width: 100%; background: #65E4A3; }
 
     .password-strength__label {
       font-size: 0.75rem;

--- a/client/src/app/features/dashboard/dashboard.component.ts
+++ b/client/src/app/features/dashboard/dashboard.component.ts
@@ -152,7 +152,7 @@ import { CurrencyClpPipe } from '../../shared/pipes/currency-clp.pipe';
 
     .quick-actions-card,
     .recent-transactions-card {
-      border-radius: 16px !important;
+      border-radius: 0.5rem !important;
       margin-bottom: 24px;
     }
 
@@ -169,7 +169,7 @@ import { CurrencyClpPipe } from '../../shared/pipes/currency-clp.pipe';
       align-items: center;
       gap: 8px;
       padding: 20px 24px;
-      border-radius: 16px !important;
+      border-radius: 0.5rem !important;
       min-width: 120px;
       font-size: 0.8125rem;
     }
@@ -178,7 +178,7 @@ import { CurrencyClpPipe } from '../../shared/pipes/currency-clp.pipe';
       font-size: 28px;
       width: 28px;
       height: 28px;
-      color: var(--mb-primary, #1976D2);
+      color: #0A2640;
     }
 
     .recent-transactions-card mat-card-header {
@@ -215,7 +215,7 @@ import { CurrencyClpPipe } from '../../shared/pipes/currency-clp.pipe';
       margin-left: auto;
     }
 
-    .transaction-amount.negative { color: #D32F2F; }
+    .transaction-amount.negative { color: #DC3545; }
     .transaction-amount.positive { color: #43A047; }
 
     .empty-state {
@@ -227,7 +227,7 @@ import { CurrencyClpPipe } from '../../shared/pipes/currency-clp.pipe';
       font-size: 56px;
       width: 56px;
       height: 56px;
-      color: #BDBDBD;
+      color: #C4C4C4;
     }
 
     .empty-state__text {

--- a/client/src/app/features/history/history.component.ts
+++ b/client/src/app/features/history/history.component.ts
@@ -148,7 +148,7 @@ import { CurrencyClpPipe } from '../../shared/pipes/currency-clp.pipe';
   `,
   styles: [`
     .history-card {
-      border-radius: 16px !important;
+      border-radius: 0.5rem !important;
       overflow: hidden;
     }
 
@@ -185,29 +185,29 @@ import { CurrencyClpPipe } from '../../shared/pipes/currency-clp.pipe';
 
     .cell-amount {
       font-weight: 700;
-      color: #D32F2F;
+      color: #DC3545;
       white-space: nowrap;
     }
 
     .chip-type {
-      --mat-chip-elevated-container-color: #E3F2FD;
-      --mat-chip-label-text-color: #1565C0;
+      --mat-chip-elevated-container-color: #CFF4FC;
+      --mat-chip-label-text-color: #0AA2C0;
       font-size: 0.75rem;
     }
 
     .chip-completada {
-      --mat-chip-elevated-container-color: #C8E6C9;
-      --mat-chip-label-text-color: #388E3C;
+      --mat-chip-elevated-container-color: #E0FAED;
+      --mat-chip-label-text-color: #2E8B57;
     }
 
     .chip-pendiente {
-      --mat-chip-elevated-container-color: #FFE0B2;
-      --mat-chip-label-text-color: #F57C00;
+      --mat-chip-elevated-container-color: #FFF3E0;
+      --mat-chip-label-text-color: #E56B00;
     }
 
     .chip-rechazada {
-      --mat-chip-elevated-container-color: #FFCDD2;
-      --mat-chip-label-text-color: #C62828;
+      --mat-chip-elevated-container-color: #FBE7E9;
+      --mat-chip-label-text-color: #B72C39;
     }
 
     .loading-state,
@@ -221,7 +221,7 @@ import { CurrencyClpPipe } from '../../shared/pipes/currency-clp.pipe';
       font-size: 64px;
       width: 64px;
       height: 64px;
-      color: #BDBDBD;
+      color: #C4C4C4;
     }
 
     .empty-state h3 {

--- a/client/src/app/features/profile/profile.component.ts
+++ b/client/src/app/features/profile/profile.component.ts
@@ -145,7 +145,7 @@ import { rutValidator } from '../../shared/validators/rut.validator';
 
     .profile-summary-card,
     .profile-edit-card {
-      border-radius: 16px !important;
+      border-radius: 0.5rem !important;
     }
 
     .profile-summary-card {
@@ -161,7 +161,7 @@ import { rutValidator } from '../../shared/validators/rut.validator';
       font-size: 80px;
       width: 80px;
       height: 80px;
-      color: #1976D2;
+      color: #0A2640;
     }
 
     .profile-name {
@@ -171,7 +171,7 @@ import { rutValidator } from '../../shared/validators/rut.validator';
     }
 
     .profile-rut {
-      color: #757575;
+      color: #5B7075;
       font-size: 0.875rem;
       margin: 0 0 16px;
     }
@@ -204,12 +204,12 @@ import { rutValidator } from '../../shared/validators/rut.validator';
       align-items: center;
       gap: 16px;
       padding: 12px 16px;
-      border-radius: 12px;
-      background: #F5F5F5;
+      border-radius: 0.5rem;
+      background: #F1F1F1;
     }
 
     .security-item__icon {
-      color: #1976D2;
+      color: #0A2640;
       font-size: 28px;
       width: 28px;
       height: 28px;
@@ -230,14 +230,14 @@ import { rutValidator } from '../../shared/validators/rut.validator';
     .submit-btn {
       height: 48px;
       padding: 0 32px;
-      border-radius: 12px !important;
+      border-radius: 5rem !important;
     }
 
     .submit-btn mat-icon { margin-right: 8px; }
 
     .chip-success {
-      --mat-chip-elevated-container-color: #C8E6C9;
-      --mat-chip-label-text-color: #388E3C;
+      --mat-chip-elevated-container-color: #E0FAED;
+      --mat-chip-label-text-color: #2E8B57;
     }
   `]
 })

--- a/client/src/app/features/transfers/new-beneficiary/new-beneficiary.component.ts
+++ b/client/src/app/features/transfers/new-beneficiary/new-beneficiary.component.ts
@@ -145,7 +145,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
   styles: [`
     .beneficiary-card {
       max-width: 720px;
-      border-radius: 16px !important;
+      border-radius: 0.5rem !important;
     }
 
     .full-width { width: 100%; }
@@ -172,7 +172,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
     .submit-btn {
       height: 48px;
       padding: 0 32px;
-      border-radius: 12px !important;
+      border-radius: 5rem !important;
     }
 
     .submit-btn mat-icon { margin-right: 8px; }

--- a/client/src/app/features/transfers/new-transfer/new-transfer.component.ts
+++ b/client/src/app/features/transfers/new-transfer/new-transfer.component.ts
@@ -128,7 +128,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
   styles: [`
     .transfer-card {
       max-width: 640px;
-      border-radius: 16px !important;
+      border-radius: 0.5rem !important;
     }
 
     .full-width { width: 100%; }
@@ -157,7 +157,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
     .currency-prefix {
       font-size: 1.25rem;
       font-weight: 500;
-      color: #757575;
+      color: #5B7075;
     }
 
     .form-actions {
@@ -170,7 +170,7 @@ import { rutValidator } from '../../../shared/validators/rut.validator';
       height: 48px;
       padding: 0 32px;
       font-size: 1rem;
-      border-radius: 12px !important;
+      border-radius: 5rem !important;
     }
 
     .submit-btn mat-icon { margin-right: 8px; }

--- a/client/src/app/layout/layout.component.ts
+++ b/client/src/app/layout/layout.component.ts
@@ -1,13 +1,12 @@
-import { Component, signal, computed, inject, OnInit, ViewChild } from '@angular/core';
+import { Component, signal, inject, OnInit } from '@angular/core';
 import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatSidenavModule, MatSidenav } from '@angular/material/sidenav';
+import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatBadgeModule } from '@angular/material/badge';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { AuthService } from '../core/auth/auth.service';
@@ -31,13 +30,12 @@ interface NavItem {
     MatIconModule,
     MatButtonModule,
     MatMenuModule,
-    MatBadgeModule,
     MatDividerModule,
     MatTooltipModule
   ],
   template: `
     <mat-sidenav-container class="layout-container">
-      <!-- Sidenav for mobile -->
+      <!-- Sidenav: Boldo dark navy -->
       <mat-sidenav
         #sidenav
         [mode]="isMobile() ? 'over' : 'side'"
@@ -51,9 +49,9 @@ interface NavItem {
           <span class="sidenav-brand">Mi Banco</span>
         </div>
 
-        <mat-divider></mat-divider>
+        <div class="sidenav-divider"></div>
 
-        <mat-nav-list>
+        <mat-nav-list class="sidenav-nav">
           @for (item of navItems; track item.route) {
             <a mat-list-item
                [routerLink]="item.route"
@@ -67,9 +65,9 @@ interface NavItem {
         </mat-nav-list>
 
         <div class="sidenav-footer">
-          <mat-divider></mat-divider>
+          <div class="sidenav-divider"></div>
           <mat-nav-list>
-            <a mat-list-item (click)="logout()">
+            <a mat-list-item (click)="logout()" class="logout-item">
               <mat-icon matListItemIcon>logout</mat-icon>
               <span matListItemTitle>Cerrar Sesion</span>
             </a>
@@ -77,10 +75,10 @@ interface NavItem {
         </div>
       </mat-sidenav>
 
-      <!-- Main content area -->
+      <!-- Main content -->
       <mat-sidenav-content class="layout-content">
-        <!-- Top toolbar -->
-        <mat-toolbar class="layout-toolbar" color="primary">
+        <!-- Toolbar: clean white -->
+        <mat-toolbar class="layout-toolbar">
           @if (isMobile()) {
             <button mat-icon-button
                     (click)="sidenav.toggle()"
@@ -91,11 +89,11 @@ interface NavItem {
 
           <span class="toolbar-spacer"></span>
 
-          <!-- User menu -->
           <button mat-icon-button
                   [matMenuTriggerFor]="userMenu"
                   aria-label="Menu de usuario"
-                  matTooltip="Mi cuenta">
+                  matTooltip="Mi cuenta"
+                  class="user-avatar-btn">
             <mat-icon>account_circle</mat-icon>
           </button>
 
@@ -115,7 +113,6 @@ interface NavItem {
           </mat-menu>
         </mat-toolbar>
 
-        <!-- Page content -->
         <main class="page-content" role="main">
           <router-outlet />
         </main>
@@ -129,59 +126,99 @@ interface NavItem {
 
     .layout-sidenav {
       width: 260px;
-      background: var(--mb-surface, #fff);
-      border-right: 1px solid var(--mb-divider, #e0e0e0);
+      background: #0A2640;
+      border-right: none;
     }
 
     .sidenav-header {
       display: flex;
       align-items: center;
       gap: 12px;
-      padding: 20px 16px;
+      padding: 24px 20px;
     }
 
     .sidenav-logo {
       font-size: 32px;
       width: 32px;
       height: 32px;
-      color: var(--mb-primary, #1976D2);
+      color: #65E4A3;
     }
 
     .sidenav-brand {
       font-size: 1.25rem;
       font-weight: 700;
-      color: var(--mb-primary, #1976D2);
+      color: #ffffff;
       letter-spacing: -0.5px;
+    }
+
+    .sidenav-divider {
+      height: 1px;
+      background: rgba(255, 255, 255, 0.1);
+      margin: 0 16px;
+    }
+
+    .sidenav-nav .mat-mdc-list-item {
+      color: rgba(255, 255, 255, 0.7);
+      margin: 2px 8px;
+      border-radius: 0.5rem;
+    }
+    .sidenav-nav .mat-mdc-list-item:hover {
+      background: rgba(255, 255, 255, 0.08);
+      color: #F1F1F1;
+    }
+    .sidenav-nav .mat-mdc-list-item .mat-icon {
+      color: rgba(255, 255, 255, 0.5);
+    }
+
+    .active-link {
+      background: rgba(101, 228, 163, 0.12) !important;
+      color: #65E4A3 !important;
+    }
+    .active-link .mat-icon {
+      color: #65E4A3 !important;
     }
 
     .sidenav-footer {
       margin-top: auto;
     }
 
-    .active-link {
-      background: rgba(25, 118, 210, 0.08) !important;
-      color: var(--mb-primary, #1976D2) !important;
-      border-left: 3px solid var(--mb-primary, #1976D2);
+    .logout-item {
+      color: rgba(255, 255, 255, 0.5) !important;
+    }
+    .logout-item:hover {
+      color: #E57373 !important;
+      background: rgba(229, 115, 115, 0.08) !important;
     }
 
     .layout-toolbar {
       position: sticky;
       top: 0;
       z-index: 100;
+      background: #ffffff;
+      color: #0A2640;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
     }
 
     .toolbar-spacer {
       flex: 1;
     }
 
+    .user-avatar-btn .mat-icon {
+      font-size: 28px;
+      width: 28px;
+      height: 28px;
+      color: #0A2640;
+    }
+
     .layout-content {
       display: flex;
       flex-direction: column;
+      background: #F7F9FA;
     }
 
     .page-content {
       flex: 1;
-      padding: 24px;
+      padding: 32px;
       max-width: 1200px;
       width: 100%;
       margin: 0 auto;

--- a/client/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/client/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -55,10 +55,10 @@ export interface ConfirmDialogData {
       margin: 0 auto 16px;
     }
 
-    .confirm-dialog__icon-wrapper--info { background: rgba(41, 182, 246, 0.12); color: #29B6F6; }
-    .confirm-dialog__icon-wrapper--success { background: rgba(67, 160, 71, 0.12); color: #43A047; }
-    .confirm-dialog__icon-wrapper--warning { background: rgba(255, 167, 38, 0.12); color: #FFA726; }
-    .confirm-dialog__icon-wrapper--error { background: rgba(211, 47, 47, 0.12); color: #D32F2F; }
+    .confirm-dialog__icon-wrapper--info { background: #CFF4FC; color: #0DCAF0; }
+    .confirm-dialog__icon-wrapper--success { background: #E0FAED; color: #65E4A3; }
+    .confirm-dialog__icon-wrapper--warning { background: #FFF3E0; color: #FD7E14; }
+    .confirm-dialog__icon-wrapper--error { background: #FBE7E9; color: #DC3545; }
 
     .confirm-dialog__icon {
       font-size: 32px;

--- a/client/src/app/shared/components/page-header/page-header.component.ts
+++ b/client/src/app/shared/components/page-header/page-header.component.ts
@@ -32,19 +32,19 @@ import { MatIconModule } from '@angular/material/icon';
       font-size: 36px;
       width: 36px;
       height: 36px;
-      color: var(--mb-primary, #1976D2);
+      color: var(--mb-primary, #0A2640);
       margin-top: 2px;
     }
     .page-header__title {
       font-size: 1.75rem;
       font-weight: 700;
-      color: var(--mb-text-primary, #212121);
+      color: var(--mb-text-primary, #000000);
       margin: 0;
       letter-spacing: -0.5px;
     }
     .page-header__subtitle {
       font-size: 0.9375rem;
-      color: var(--mb-text-secondary, #616161);
+      color: var(--mb-text-secondary, #5B7075);
       margin: 4px 0 0;
     }
   `]

--- a/client/src/app/shared/components/summary-card/summary-card.component.ts
+++ b/client/src/app/shared/components/summary-card/summary-card.component.ts
@@ -28,7 +28,7 @@ import { MatIconModule } from '@angular/material/icon';
   `,
   styles: [`
     .summary-card {
-      border-radius: 16px;
+      border-radius: 0.5rem;
       transition: transform 250ms cubic-bezier(0.4, 0, 0.2, 1),
                   box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1);
     }
@@ -50,19 +50,19 @@ import { MatIconModule } from '@angular/material/icon';
     .summary-card__label {
       font-size: 0.875rem;
       font-weight: 500;
-      color: var(--mb-text-secondary, #616161);
+      color: var(--mb-text-secondary, #5B7075);
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }
     .summary-card__value {
       font-size: 1.75rem;
       font-weight: 700;
-      color: var(--mb-text-primary, #212121);
+      color: var(--mb-text-primary, #000000);
       letter-spacing: -0.5px;
     }
     .summary-card__subtitle {
       font-size: 0.8125rem;
-      color: var(--mb-text-secondary, #616161);
+      color: var(--mb-text-secondary, #5B7075);
     }
     .summary-card__icon-wrapper {
       width: 56px;
@@ -78,20 +78,20 @@ import { MatIconModule } from '@angular/material/icon';
       height: 28px;
     }
     .summary-card--primary .summary-card__icon-wrapper {
-      background: rgba(25, 118, 210, 0.12);
-      color: #1976D2;
+      background: rgba(10, 38, 64, 0.08);
+      color: #0A2640;
     }
     .summary-card--success .summary-card__icon-wrapper {
-      background: rgba(67, 160, 71, 0.12);
-      color: #43A047;
+      background: rgba(101, 228, 163, 0.12);
+      color: #65E4A3;
     }
     .summary-card--warning .summary-card__icon-wrapper {
-      background: rgba(251, 140, 0, 0.12);
-      color: #FB8C00;
+      background: rgba(253, 126, 20, 0.12);
+      color: #FD7E14;
     }
     .summary-card--accent .summary-card__icon-wrapper {
-      background: rgba(156, 39, 176, 0.12);
-      color: #9C27B0;
+      background: rgba(13, 202, 240, 0.12);
+      color: #0DCAF0;
     }
   `]
 })

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -10,7 +10,7 @@
   <meta name="theme-color" content="#1976D2">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body class="mat-typography">

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -1,19 +1,14 @@
 // ============================================================================
-// MI-BANCO - ESTILOS GLOBALES
-// Punto de entrada para el sistema de diseño bancario
+// MI-BANCO - ESTILOS GLOBALES (Boldo-inspired)
+// Manrope font, navy + green palette, pill-shaped controls
 // ============================================================================
 
-// Importar tema Material Design custom
 @use './styles/banking-theme';
-
-// Importar variables (ya incluidas en banking-theme, pero disponibles aquí si se necesitan)
 @use './styles/variables' as vars;
-
-// Importar utilidades
 @use './styles/utilities';
 
 // ----------------------------------------------------------------------------
-// ESTILOS GLOBALES BASE
+// BASE
 // ----------------------------------------------------------------------------
 html,
 body {
@@ -26,7 +21,7 @@ body {
   font-family: vars.$font-family-base;
   font-size: vars.$font-size-body;
   line-height: vars.$line-height-normal;
-  color: vars.$text-primary;
+  color: vars.$text-secondary;
   background-color: vars.$background-page;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -37,54 +32,34 @@ body {
 }
 
 // ----------------------------------------------------------------------------
-// RESET Y NORMALIZACIÓN
+// TYPOGRAPHY (Boldo: black headings, Manrope, 1.2 line-height)
 // ----------------------------------------------------------------------------
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, h2, h3, h4, h5, h6 {
   margin: 0;
-  font-weight: vars.$font-weight-medium;
+  font-weight: vars.$font-weight-bold;
   line-height: vars.$line-height-tight;
+  color: vars.$text-primary;
 }
 
-h1 {
-  font-size: vars.$font-size-h1;
-}
-
-h2 {
-  font-size: vars.$font-size-h2;
-}
-
-h3 {
-  font-size: vars.$font-size-h3;
-}
-
-h4 {
-  font-size: vars.$font-size-h4;
-}
-
-h5 {
-  font-size: vars.$font-size-h5;
-}
-
-h6 {
-  font-size: vars.$font-size-h6;
-}
+h1 { font-size: vars.$font-size-h1; }
+h2 { font-size: vars.$font-size-h2; }
+h3 { font-size: vars.$font-size-h3; }
+h4 { font-size: vars.$font-size-h4; }
+h5 { font-size: vars.$font-size-h5; }
+h6 { font-size: vars.$font-size-h6; }
 
 p {
   margin: 0 0 vars.$spacing-md 0;
+  color: vars.$text-secondary;
 }
 
 a {
-  color: vars.$primary-500;
+  color: vars.$secondary-500;
   text-decoration: none;
   transition: color vars.$transition-fast;
 
   &:hover {
-    color: vars.$primary-700;
+    color: vars.$secondary-700;
     text-decoration: underline;
   }
 
@@ -105,7 +80,7 @@ button {
 }
 
 // ----------------------------------------------------------------------------
-// LAYOUT PRINCIPAL
+// LAYOUT
 // ----------------------------------------------------------------------------
 .main-content {
   min-height: calc(100vh - vars.$toolbar-height);
@@ -122,7 +97,7 @@ button {
 
   &__title {
     font-size: vars.$font-size-h3;
-    font-weight: vars.$font-weight-medium;
+    font-weight: vars.$font-weight-bold;
     color: vars.$text-primary;
     margin-bottom: vars.$spacing-sm;
   }
@@ -134,7 +109,7 @@ button {
 }
 
 // ----------------------------------------------------------------------------
-// CARDS Y CONTENEDORES
+// CARDS (Boldo card radius 0.5rem)
 // ----------------------------------------------------------------------------
 .card {
   background-color: vars.$background-card;
@@ -154,7 +129,7 @@ button {
 
     &-title {
       font-size: vars.$font-size-h5;
-      font-weight: vars.$font-weight-medium;
+      font-weight: vars.$font-weight-bold;
       color: vars.$text-primary;
       margin: 0;
     }
@@ -164,10 +139,6 @@ button {
       font-size: vars.$font-size-small;
       margin-top: vars.$spacing-xs;
     }
-  }
-
-  &__content {
-    // Contenido principal de la card
   }
 
   &__actions {
@@ -188,7 +159,7 @@ button {
 }
 
 // ----------------------------------------------------------------------------
-// FORMULARIOS
+// FORMS
 // ----------------------------------------------------------------------------
 .form-row {
   display: grid;
@@ -210,7 +181,7 @@ button {
 }
 
 // ----------------------------------------------------------------------------
-// ESTADOS DE VALIDACIÓN
+// VALIDATION
 // ----------------------------------------------------------------------------
 .validation-error {
   color: vars.$error-500;
@@ -228,7 +199,7 @@ button {
 }
 
 // ----------------------------------------------------------------------------
-// TABLAS RESPONSIVE
+// TABLES
 // ----------------------------------------------------------------------------
 .table-container {
   overflow-x: auto;
@@ -237,21 +208,20 @@ button {
   border-radius: vars.$border-radius-md;
 
   @media (max-width: vars.$breakpoint-md) {
-    // Scroll horizontal en móviles
     -webkit-overflow-scrolling: touch;
   }
 }
 
 // ----------------------------------------------------------------------------
-// BADGES Y CHIPS
+// BADGES (pill-shaped, Boldo style)
 // ----------------------------------------------------------------------------
 .badge {
   display: inline-flex;
   align-items: center;
   padding: vars.$spacing-xs vars.$spacing-sm;
-  border-radius: vars.$border-radius-full;
+  border-radius: vars.$border-radius-pill;
   font-size: vars.$font-size-caption;
-  font-weight: vars.$font-weight-medium;
+  font-weight: vars.$font-weight-semi-bold;
   line-height: 1;
 
   &.badge-success {
@@ -290,15 +260,8 @@ button {
   margin: vars.$spacing-lg 0;
 }
 
-.divider-vertical {
-  width: 1px;
-  background-color: vars.$divider-color;
-  border: none;
-  margin: 0 vars.$spacing-md;
-}
-
 // ----------------------------------------------------------------------------
-// SCROLLBARS PERSONALIZADOS (Webkit)
+// SCROLLBARS
 // ----------------------------------------------------------------------------
 ::-webkit-scrollbar {
   width: 8px;
@@ -311,7 +274,7 @@ button {
 
 ::-webkit-scrollbar-thumb {
   background: vars.$gray-400;
-  border-radius: vars.$border-radius-sm;
+  border-radius: vars.$border-radius-pill;
 
   &:hover {
     background: vars.$gray-500;
@@ -319,7 +282,41 @@ button {
 }
 
 // ----------------------------------------------------------------------------
-// PRINT STYLES
+// BOLDO UTILITY CLASSES
+// ----------------------------------------------------------------------------
+.bg-dark {
+  background-color: vars.$primary-500;
+  color: white;
+}
+
+.text-success {
+  color: vars.$accent-500;
+}
+
+.text-muted {
+  color: vars.$text-secondary;
+}
+
+.btn-success {
+  background-color: vars.$accent-500 !important;
+  color: vars.$primary-500 !important;
+
+  &:hover {
+    background-color: vars.$accent-700 !important;
+  }
+}
+
+.btn-dark {
+  background-color: vars.$primary-500 !important;
+  color: white !important;
+
+  &:hover {
+    background-color: vars.$primary-700 !important;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// PRINT
 // ----------------------------------------------------------------------------
 @media print {
   .no-print {
@@ -338,7 +335,7 @@ button {
 }
 
 // ----------------------------------------------------------------------------
-// ACCESIBILIDAD - MOTION REDUCTION
+// REDUCED MOTION
 // ----------------------------------------------------------------------------
 @media (prefers-reduced-motion: reduce) {
   *,
@@ -351,7 +348,7 @@ button {
 }
 
 // ----------------------------------------------------------------------------
-// HIGH CONTRAST MODE
+// HIGH CONTRAST
 // ----------------------------------------------------------------------------
 @media (prefers-contrast: high) {
   .mat-card,

--- a/client/src/styles/_banking-theme.scss
+++ b/client/src/styles/_banking-theme.scss
@@ -1,183 +1,170 @@
 // ============================================================================
-// MI-BANCO - TEMA MATERIAL 3 EXPRESSIVE
-// Material Design 3 con colores vibrantes y personalidad financiera
-// Compatible con Angular Material 21
+// MI-BANCO - TEMA MATERIAL 3 (Boldo-inspired)
+// Navy + Green CTA + Cyan accents con pill-shaped components
 // ============================================================================
 
 @use '@angular/material' as mat;
 @use './variables' as vars;
 
 // ----------------------------------------------------------------------------
-// MATERIAL 3 THEME CONFIGURATION
-// Usando M3 theme API con paletas de Angular Material 21
+// MATERIAL 3 THEME - Boldo-adapted palette
 // ----------------------------------------------------------------------------
 
 $mi-banco-theme: mat.define-theme((
   color: (
     theme-type: light,
-    primary: mat.$blue-palette,
-    tertiary: mat.$orange-palette,
+    primary: mat.$cyan-palette,
+    tertiary: mat.$green-palette,
   ),
   typography: (
-    brand-family: 'Roboto',
-    plain-family: 'Roboto',
+    brand-family: 'Manrope',
+    plain-family: 'Manrope',
   ),
   density: (
     scale: 0,
   )
 ));
 
-// Apply the theme globally
 html {
   @include mat.all-component-themes($mi-banco-theme);
 }
 
 // ----------------------------------------------------------------------------
-// CSS CUSTOM PROPERTIES (Design Tokens M3 Expressive)
-// Para uso consistente en componentes standalone
+// CSS CUSTOM PROPERTIES (Boldo Design Tokens)
 // ----------------------------------------------------------------------------
 :root {
-  // Primary palette
   --mb-primary: #{vars.$primary-500};
   --mb-primary-light: #{vars.$primary-100};
   --mb-primary-dark: #{vars.$primary-700};
   --mb-on-primary: #ffffff;
 
-  // Accent / Tertiary
   --mb-accent: #{vars.$accent-500};
   --mb-accent-light: #{vars.$accent-100};
+  --mb-accent-dark: #{vars.$accent-700};
 
-  // Semantic colors
+  --mb-secondary: #{vars.$secondary-500};
+  --mb-secondary-light: #{vars.$secondary-100};
+
   --mb-success: #{vars.$success-500};
   --mb-error: #{vars.$error-500};
   --mb-warning: #{vars.$warning-500};
   --mb-info: #{vars.$info-500};
 
-  // Surfaces
   --mb-surface: #ffffff;
-  --mb-surface-variant: #{vars.$gray-50};
+  --mb-surface-variant: #{vars.$gray-100};
   --mb-background: #{vars.$background-page};
+  --mb-background-dark: #{vars.$primary-500};
   --mb-divider: #{vars.$divider-color};
 
-  // Text
   --mb-text-primary: #{vars.$text-primary};
   --mb-text-secondary: #{vars.$text-secondary};
+  --mb-text-on-dark: #{vars.$text-on-dark};
+  --mb-text-on-dark-muted: #{vars.$text-on-dark-muted};
 
-  // Elevation
   --mb-shadow-sm: #{vars.$shadow-1};
   --mb-shadow-md: #{vars.$shadow-2};
   --mb-shadow-lg: #{vars.$shadow-3};
+  --mb-shadow-btn: #{vars.$shadow-4};
 
-  // Shape (M3 Expressive rounded corners)
-  --mb-shape-sm: 8px;
-  --mb-shape-md: 12px;
-  --mb-shape-lg: 16px;
-  --mb-shape-xl: 24px;
-  --mb-shape-full: 9999px;
+  --mb-shape-sm: #{vars.$border-radius-sm};
+  --mb-shape-md: #{vars.$border-radius-md};
+  --mb-shape-lg: #{vars.$border-radius-lg};
+  --mb-shape-xl: #{vars.$border-radius-xl};
+  --mb-shape-pill: #{vars.$border-radius-pill};
 
-  // Motion (M3 Expressive emphasis curves)
-  --mb-motion-standard: 300ms cubic-bezier(0.2, 0, 0, 1);
-  --mb-motion-emphasized: 500ms cubic-bezier(0.2, 0, 0, 1);
+  --mb-motion-standard: #{vars.$transition-base};
+  --mb-motion-fast: #{vars.$transition-fast};
 }
 
 // ----------------------------------------------------------------------------
-// M3 EXPRESSIVE COMPONENT OVERRIDES
-// Colores vibrantes, tipografia audaz, animaciones dinamicas
+// BOLDO COMPONENT OVERRIDES
 // ----------------------------------------------------------------------------
 
-// Toolbar con gradiente sutil y elevacion
+/* Toolbar: dark navy background */
 .mat-toolbar.mat-primary {
-  background: linear-gradient(135deg, vars.$primary-500, vars.$primary-700);
+  background: vars.$primary-500;
   color: white;
   box-shadow: vars.$shadow-2;
 }
 
-// Cards con bordes redondeados M3 y hover expresivo
+/* Cards: Boldo subtle shadow, soft radius */
 .mat-mdc-card {
-  border-radius: var(--mb-shape-lg) !important;
+  border-radius: var(--mb-shape-md) !important;
   box-shadow: var(--mb-shadow-md);
-  transition: transform var(--mb-motion-standard),
-              box-shadow var(--mb-motion-standard);
-
-  &:hover {
-    box-shadow: var(--mb-shadow-lg);
-  }
+  transition: transform vars.$transition-base, box-shadow vars.$transition-base;
+}
+.mat-mdc-card:hover {
+  box-shadow: var(--mb-shadow-lg);
 }
 
-// Form fields
+/* Form fields */
 .mat-mdc-form-field {
   font-family: vars.$font-family-base;
 }
 
-// Botones M3 Expressive
+/* Buttons: pill-shaped (Boldo signature) */
 .mat-mdc-button,
 .mat-mdc-raised-button,
 .mat-mdc-unelevated-button,
 .mat-mdc-outlined-button,
 .mat-mdc-flat-button {
-  border-radius: var(--mb-shape-md) !important;
-  font-weight: vars.$font-weight-medium;
+  border-radius: var(--mb-shape-pill) !important;
+  font-weight: vars.$font-weight-bold;
   letter-spacing: 0.3px;
-  transition: all var(--mb-motion-standard);
+  transition: all vars.$transition-fast;
+  border-width: vars.$border-width-thick;
 }
 
 .mat-mdc-fab,
 .mat-mdc-mini-fab {
-  border-radius: var(--mb-shape-lg) !important;
+  border-radius: var(--mb-shape-xl) !important;
 }
 
-// Snackbars semanticos
+/* Snackbars */
 .mat-mdc-snack-bar-container {
-  &.success-snackbar {
-    --mat-snackbar-container-color: #{vars.$success-500};
-    --mat-snack-bar-button-color: #{vars.$success-100};
-    --mat-snackbar-supporting-text-color: white;
-  }
-
-  &.error-snackbar {
-    --mat-snackbar-container-color: #{vars.$error-500};
-    --mat-snack-bar-button-color: #{vars.$error-100};
-    --mat-snackbar-supporting-text-color: white;
-  }
-
-  &.warning-snackbar {
-    --mat-snackbar-container-color: #{vars.$warning-700};
-    --mat-snack-bar-button-color: #{vars.$warning-100};
-    --mat-snackbar-supporting-text-color: white;
-  }
-
-  &.info-snackbar {
-    --mat-snackbar-container-color: #{vars.$info-500};
-    --mat-snack-bar-button-color: #{vars.$info-100};
-    --mat-snackbar-supporting-text-color: white;
-  }
+  border-radius: var(--mb-shape-md) !important;
+}
+.mat-mdc-snack-bar-container.success-snackbar {
+  --mat-snackbar-container-color: #{vars.$accent-500};
+  --mat-snack-bar-button-color: #{vars.$primary-500};
+  --mat-snackbar-supporting-text-color: #{vars.$primary-500};
+}
+.mat-mdc-snack-bar-container.error-snackbar {
+  --mat-snackbar-container-color: #{vars.$error-500};
+  --mat-snack-bar-button-color: #{vars.$error-100};
+  --mat-snackbar-supporting-text-color: white;
+}
+.mat-mdc-snack-bar-container.warning-snackbar {
+  --mat-snackbar-container-color: #{vars.$warning-700};
+  --mat-snack-bar-button-color: #{vars.$warning-100};
+  --mat-snackbar-supporting-text-color: white;
+}
+.mat-mdc-snack-bar-container.info-snackbar {
+  --mat-snackbar-container-color: #{vars.$secondary-500};
+  --mat-snack-bar-button-color: #{vars.$primary-500};
+  --mat-snackbar-supporting-text-color: #{vars.$primary-500};
 }
 
-// Tablas bancarias
+/* Tables */
 .mat-mdc-table {
   background-color: white;
-
-  .mat-mdc-header-row {
-    background-color: vars.$gray-50;
-  }
-
-  .mat-mdc-row {
-    transition: background-color var(--mb-motion-standard);
-
-    &:hover {
-      background-color: vars.$background-hover;
-    }
-  }
-
-  .mat-mdc-header-cell {
-    color: vars.$text-primary;
-    font-weight: vars.$font-weight-medium;
-    font-size: vars.$font-size-small;
-  }
-
-  .mat-mdc-cell {
-    color: vars.$text-secondary;
-  }
+}
+.mat-mdc-table .mat-mdc-header-row {
+  background-color: vars.$gray-100;
+}
+.mat-mdc-table .mat-mdc-row {
+  transition: background-color vars.$transition-fast;
+}
+.mat-mdc-table .mat-mdc-row:hover {
+  background-color: vars.$background-hover;
+}
+.mat-mdc-table .mat-mdc-header-cell {
+  color: vars.$text-primary;
+  font-weight: vars.$font-weight-semi-bold;
+  font-size: vars.$font-size-small;
+}
+.mat-mdc-table .mat-mdc-cell {
+  color: vars.$text-secondary;
 }
 
 .mat-mdc-paginator {
@@ -185,61 +172,57 @@ html {
   border-top: 1px solid vars.$divider-color;
 }
 
-.mat-mdc-tab-group {
-  .mat-mdc-tab {
-    font-weight: vars.$font-weight-medium;
-    min-width: 120px;
-  }
+.mat-mdc-tab-group .mat-mdc-tab {
+  font-weight: vars.$font-weight-semi-bold;
+  min-width: 120px;
 }
 
-// Dialog M3
+/* Dialog */
 .mat-mdc-dialog-container {
-  border-radius: var(--mb-shape-xl) !important;
+  border-radius: var(--mb-shape-lg) !important;
 }
 
+/* Menu */
 .mat-mdc-menu-panel {
   border-radius: var(--mb-shape-md) !important;
 }
 
-// Chips semanticos
+/* Chips: pill-shaped */
 .mat-mdc-chip {
-  border-radius: var(--mb-shape-sm) !important;
-
-  &.chip-success {
-    --mat-chip-elevated-container-color: #{vars.$success-100};
-    --mat-chip-label-text-color: #{vars.$success-700};
-  }
-
-  &.chip-error {
-    --mat-chip-elevated-container-color: #{vars.$error-100};
-    --mat-chip-label-text-color: #{vars.$error-700};
-  }
-
-  &.chip-warning {
-    --mat-chip-elevated-container-color: #{vars.$warning-100};
-    --mat-chip-label-text-color: #{vars.$warning-700};
-  }
-
-  &.chip-info {
-    --mat-chip-elevated-container-color: #{vars.$info-100};
-    --mat-chip-label-text-color: #{vars.$info-700};
-  }
+  border-radius: var(--mb-shape-pill) !important;
+}
+.mat-mdc-chip.chip-success {
+  --mat-chip-elevated-container-color: #{vars.$success-100};
+  --mat-chip-label-text-color: #{vars.$success-700};
+}
+.mat-mdc-chip.chip-error {
+  --mat-chip-elevated-container-color: #{vars.$error-100};
+  --mat-chip-label-text-color: #{vars.$error-700};
+}
+.mat-mdc-chip.chip-warning {
+  --mat-chip-elevated-container-color: #{vars.$warning-100};
+  --mat-chip-label-text-color: #{vars.$warning-700};
+}
+.mat-mdc-chip.chip-info {
+  --mat-chip-elevated-container-color: #{vars.$info-100};
+  --mat-chip-label-text-color: #{vars.$info-700};
 }
 
+/* Progress spinner */
 .mat-mdc-progress-spinner {
-  --mat-progress-spinner-active-indicator-color: #{vars.$primary-500};
+  --mat-progress-spinner-active-indicator-color: #{vars.$secondary-500};
 }
 
+/* Sidenav */
 .mat-sidenav {
-  border-radius: 0 var(--mb-shape-lg) var(--mb-shape-lg) 0;
+  border-radius: 0;
 }
 
-// Focus visible mejorado (WCAG 2.0 AA)
+/* Focus visible (WCAG 2.0 AA) */
 *:focus-visible {
   outline: vars.$focus-ring-width solid vars.$focus-ring-color;
   outline-offset: vars.$focus-ring-offset;
 }
-
 button:focus-visible,
 a:focus-visible,
 input:focus-visible,

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -1,90 +1,105 @@
 // ============================================================================
-// MI-BANCO - VARIABLES DE DISEÑO
-// Sistema de diseño bancario profesional con paleta de confianza
+// MI-BANCO - VARIABLES DE DISEÑO (Boldo-inspired)
+// Design system bancario moderno con paleta navy + green CTA
+// Inspirado en: https://themewagon.github.io/boldo/
 // ============================================================================
 
 // ----------------------------------------------------------------------------
-// PALETA DE COLORES BANCARIA
+// PALETA DE COLORES BOLDO-BANKING
 // ----------------------------------------------------------------------------
-// Primario: Azul corporativo - transmite confianza, seguridad, profesionalismo
-$primary-500: #1976D2;
-$primary-700: #1565C0;
-$primary-900: #0D47A1;
-$primary-300: #42A5F5;
-$primary-100: #BBDEFB;
-$primary-50: #E3F2FD;
+// Primario: Deep Navy - transmite confianza, seriedad, profesionalismo
+$primary-500: #0A2640;
+$primary-700: #082035;
+$primary-900: #051626;
+$primary-300: #1A4A6D;
+$primary-100: #D1DEE8;
+$primary-50: #EBF0F4;
 
-// Acento: Naranja energético - para CTAs, acciones importantes
-$accent-500: #FB8C00;
-$accent-700: #F57C00;
-$accent-900: #E65100;
-$accent-300: #FFB74D;
-$accent-100: #FFE0B2;
+// Acento (CTA): Boldo Green - acciones principales, botones CTA
+$accent-500: #65E4A3;
+$accent-700: #54BD87;
+$accent-900: #2E8B57;
+$accent-300: #A0EEC7;
+$accent-100: #E0FAED;
 
-// Éxito: Verde - transacciones exitosas, confirmaciones
-$success-500: #43A047;
+// Secondary: Cyan (Boldo Primary) - links, elementos activos, highlights
+$secondary-500: #0DCAF0;
+$secondary-700: #0AA2C0;
+$secondary-300: #86E5F8;
+$secondary-100: #CFF4FC;
+
+// Exito: Verde - transacciones exitosas, confirmaciones
+$success-500: #65E4A3;
 $success-700: #388E3C;
-$success-300: #66BB6A;
-$success-100: #C8E6C9;
+$success-300: #A0EEC7;
+$success-100: #E0FAED;
 
 // Error: Rojo - advertencias, validaciones fallidas
-$error-500: #D32F2F;
-$error-700: #C62828;
+$error-500: #DC3545;
+$error-700: #B72C39;
 $error-300: #E57373;
-$error-100: #FFCDD2;
+$error-100: #FBE7E9;
 
-// Warning: Ámbar - acciones que requieren atención
-$warning-500: #FFA726;
-$warning-700: #F57C00;
+// Warning: Orange - acciones que requieren atencion
+$warning-500: #FD7E14;
+$warning-700: #E56B00;
 $warning-300: #FFB74D;
-$warning-100: #FFE0B2;
+$warning-100: #FFF3E0;
 
-// Información: Azul claro - mensajes informativos
-$info-500: #29B6F6;
-$info-700: #0288D1;
-$info-300: #4FC3F7;
-$info-100: #B3E5FC;
-
-// ----------------------------------------------------------------------------
-// ESCALA DE GRISES (WCAG AA Compliant)
-// Todos los ratios de contraste validados ≥4.5:1
-// ----------------------------------------------------------------------------
-$gray-900: #212121; // Textos principales - ratio 16.1:1 sobre blanco
-$gray-800: #424242; // Textos secundarios - ratio 11.9:1
-$gray-700: #616161; // Textos terciarios - ratio 7.6:1
-$gray-600: #757575; // Labels, placeholders - ratio 6.0:1
-$gray-500: #9E9E9E; // Disabled text - ratio 3.9:1
-$gray-400: #BDBDBD; // Bordes, divisores - ratio 2.9:1
-$gray-300: #E0E0E0; // Backgrounds secundarios
-$gray-200: #EEEEEE; // Backgrounds claros
-$gray-100: #F5F5F5; // Backgrounds sutiles
-$gray-50: #FAFAFA;  // Backgrounds página
+// Informacion: Indigo/Purple
+$info-500: #6610F2;
+$info-700: #5300CC;
+$info-300: #A480F2;
+$info-100: #E8DEFE;
 
 // ----------------------------------------------------------------------------
-// COLORES SEMÁNTICOS
+// ESCALA DE GRISES (Boldo palette + WCAG AA)
 // ----------------------------------------------------------------------------
-$text-primary: $gray-900;
-$text-secondary: $gray-700;
+$gray-900: #0A2640;   // Headings, navbar bg (Boldo Dark)
+$gray-800: #384345;   // Strong emphasis
+$gray-700: #5B7075;   // Body text (Boldo default)
+$gray-600: #627E84;   // Secondary text
+$gray-500: #76979E;   // Muted, placeholders
+$gray-400: #8E8E8E;   // Borders
+$gray-300: #C4C4C4;   // Light borders, disabled
+$gray-200: #E8ECEE;   // Light backgrounds
+$gray-100: #F1F1F1;   // Section backgrounds (Boldo Light)
+$gray-50: #F7F9FA;    // Page background
+
+// ----------------------------------------------------------------------------
+// COLORES SEMANTICOS
+// ----------------------------------------------------------------------------
+$text-primary: #000000;            // Headings (Boldo uses black for headings)
+$text-secondary: $gray-700;        // Body text (#5B7075)
 $text-disabled: $gray-500;
 $text-hint: $gray-600;
+$text-on-dark: rgba(255, 255, 255, 0.9);
+$text-on-dark-muted: rgba(255, 255, 255, 0.7);
 
 $background-page: $gray-50;
 $background-card: #FFFFFF;
-$background-hover: rgba($primary-500, 0.04);
-$background-selected: rgba($primary-500, 0.08);
-$background-disabled: $gray-200;
+$background-hover: rgba($secondary-500, 0.06);
+$background-selected: rgba($secondary-500, 0.10);
+$background-disabled: $gray-300;
+$background-dark: $primary-500;     // Dark sections (navy)
 
 $border-color: $gray-400;
 $border-light: $gray-300;
-$divider-color: $gray-300;
+$divider-color: rgba(0, 0, 0, 0.08);
+
+// Soft/tinted backgrounds (Boldo pattern)
+$soft-primary: #E2F9FD;
+$soft-success: #EDFCF4;
+$soft-danger: #FBE7E9;
+$soft-warning: #FFF3E0;
 
 // ----------------------------------------------------------------------------
-// TIPOGRAFÍA
+// TIPOGRAFIA (Manrope - Boldo's primary font)
 // ----------------------------------------------------------------------------
-$font-family-base: 'Roboto', 'Helvetica Neue', sans-serif;
-$font-family-display: 'Roboto', 'Arial', sans-serif;
+$font-family-base: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+$font-family-display: 'Manrope', 'Arial', sans-serif;
 
-// Tamaños (escala modular 1.25)
+// Tamanos (Boldo type scale 1.200 - minor third)
 $font-size-h1: 2.488rem;   // ~40px
 $font-size-h2: 2.074rem;   // ~33px
 $font-size-h3: 1.728rem;   // ~28px
@@ -99,32 +114,35 @@ $font-size-caption: 0.75rem; // 12px
 $font-weight-light: 300;
 $font-weight-regular: 400;
 $font-weight-medium: 500;
+$font-weight-semi-bold: 600;
 $font-weight-bold: 700;
 
 // Line heights
 $line-height-tight: 1.2;
-$line-height-normal: 1.5;
+$line-height-normal: 1.45;  // Boldo body line-height
 $line-height-relaxed: 1.75;
 
 // ----------------------------------------------------------------------------
-// ESPACIADO (basado en 8px grid)
+// ESPACIADO (Boldo spacer scale based on 1rem)
 // ----------------------------------------------------------------------------
-$spacing-xs: 0.25rem;  // 4px
-$spacing-sm: 0.5rem;   // 8px
-$spacing-md: 1rem;     // 16px
-$spacing-lg: 1.5rem;   // 24px
-$spacing-xl: 2rem;     // 32px
-$spacing-2xl: 3rem;    // 48px
-$spacing-3xl: 4rem;    // 64px
+$spacing-xs: 0.25rem;   // 4px
+$spacing-sm: 0.5rem;    // 8px
+$spacing-md: 1rem;      // 16px
+$spacing-lg: 1.8rem;    // ~29px (Boldo level 4)
+$spacing-xl: 3rem;      // 48px (Boldo level 5)
+$spacing-2xl: 4rem;     // 64px (Boldo level 6)
+$spacing-3xl: 5rem;     // 80px (Boldo level 7)
+$spacing-4xl: 7.5rem;   // 120px (Boldo level 8)
 
 // ----------------------------------------------------------------------------
 // BREAKPOINTS RESPONSIVE
 // ----------------------------------------------------------------------------
 $breakpoint-xs: 0;
-$breakpoint-sm: 600px;
-$breakpoint-md: 960px;
-$breakpoint-lg: 1280px;
-$breakpoint-xl: 1920px;
+$breakpoint-sm: 540px;
+$breakpoint-md: 768px;
+$breakpoint-lg: 992px;
+$breakpoint-xl: 1200px;
+$breakpoint-xxl: 1440px;
 
 // ----------------------------------------------------------------------------
 // Z-INDEX HIERARCHY
@@ -139,44 +157,45 @@ $z-index-tooltip: 1070;
 $z-index-loading-overlay: 2000;
 
 // ----------------------------------------------------------------------------
-// SOMBRAS (Material Design Elevation)
+// SOMBRAS (Boldo shadow system)
 // ----------------------------------------------------------------------------
-$shadow-1: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-$shadow-2: 0 3px 6px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.12);
-$shadow-3: 0 10px 20px rgba(0, 0, 0, 0.15), 0 3px 6px rgba(0, 0, 0, 0.10);
-$shadow-4: 0 15px 25px rgba(0, 0, 0, 0.15), 0 5px 10px rgba(0, 0, 0, 0.05);
+$shadow-1: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+$shadow-2: 0 7px 14px 0 rgba(65, 69, 88, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.07);
+$shadow-3: 0 1rem 4rem rgba(0, 0, 0, 0.175);
+$shadow-4: 0 0 0 1px rgba(43, 45, 80, 0.1), 0 2px 5px 0 rgba(43, 45, 80, 0.08), 0 1px 1.5px 0 rgba(0, 0, 0, 0.07), 0 1px 2px 0 rgba(0, 0, 0, 0.08);
 $shadow-5: 0 20px 40px rgba(0, 0, 0, 0.2);
 
 // ----------------------------------------------------------------------------
-// BORDES Y RADIOS
+// BORDES Y RADIOS (Boldo: pill buttons, rounded cards)
 // ----------------------------------------------------------------------------
-$border-radius-sm: 4px;
-$border-radius-md: 8px;
-$border-radius-lg: 12px;
-$border-radius-xl: 16px;
+$border-radius-sm: 0.3rem;         // Small elements
+$border-radius-md: 0.5rem;         // Cards (Boldo card radius)
+$border-radius-lg: 0.7rem;         // Large elements, modals
+$border-radius-xl: 1rem;           // Extra large
+$border-radius-pill: 5rem;         // Pill-shaped buttons & inputs (Boldo signature)
 $border-radius-full: 9999px;
 
 $border-width: 1px;
-$border-width-thick: 2px;
+$border-width-thick: 2px;          // Boldo uses 2px borders on buttons/inputs
 
 // ----------------------------------------------------------------------------
-// TRANSICIONES
+// TRANSICIONES (Boldo patterns)
 // ----------------------------------------------------------------------------
-$transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
-$transition-base: 250ms cubic-bezier(0.4, 0, 0.2, 1);
-$transition-slow: 350ms cubic-bezier(0.4, 0, 0.2, 1);
+$transition-fast: 150ms ease-in-out;
+$transition-base: 300ms ease;
+$transition-slow: 500ms ease;
 
 // ----------------------------------------------------------------------------
 // ACCESIBILIDAD
 // ----------------------------------------------------------------------------
-$focus-ring-color: $primary-500;
+$focus-ring-color: $secondary-300;  // Cyan for focus rings
 $focus-ring-width: 3px;
 $focus-ring-offset: 2px;
 
-$min-touch-target: 48px; // WCAG AA mínimo para dispositivos táctiles
+$min-touch-target: 48px; // WCAG AA
 
 // ----------------------------------------------------------------------------
-// COMPONENTES ESPECÍFICOS
+// COMPONENTES
 // ----------------------------------------------------------------------------
 // Toolbar/Navbar
 $toolbar-height: 64px;
@@ -186,16 +205,23 @@ $toolbar-height-mobile: 56px;
 $card-padding: $spacing-lg;
 $card-padding-mobile: $spacing-md;
 
-// Forms
+// Forms (Boldo: pill inputs with 2px border)
 $input-height: 56px;
-$input-padding-x: $spacing-md;
-$input-padding-y: $spacing-sm;
+$input-padding-x: $spacing-lg;
+$input-padding-y: $spacing-md;
 
-// Buttons
-$button-height: 40px;
-$button-padding-x: $spacing-lg;
+// Buttons (Boldo: pill shape, generous padding)
+$button-height: 48px;
+$button-padding-x: 3rem;
+$button-padding-x-sm: 1.2rem;
+$button-padding-x-lg: 5rem;
 $button-min-width: 88px;
 
 // Tables
 $table-row-height: 52px;
 $table-header-height: 56px;
+
+// Gradients (Boldo patterns)
+$gradient-primary: linear-gradient(-45deg, #1970E2, #4695FF);
+$gradient-dark: linear-gradient(135deg, $primary-500, $primary-700);
+$gradient-success: linear-gradient(135deg, $accent-500, $accent-700);


### PR DESCRIPTION
Rediseño visual completo de la aplicación siguiendo el design system de Boldo (https://themewagon.github.io/boldo/) adaptado para banca.

Design Tokens actualizados:
- Paleta primaria: Deep Navy #0A2640 (headings, sidenav, dark sections)
- CTA Green: #65E4A3 (botones principales, estados activos, éxito)
- Cyan: #0DCAF0 (links, elementos activos, highlights)
- Body text: #5B7075, Headings: #000000 (contraste Boldo)
- Tipografía: Manrope (Google Fonts) reemplaza Roboto
- Sombras: Boldo shadow system (7px/14px con rgba(65,69,88))
- Bordes: pill-shaped buttons (5rem), cards (0.5rem)

Componentes actualizados:
- Layout: sidenav dark navy con green accent en items activos, toolbar blanco limpio, fondo página #F7F9FA
- Login/Register: fondo dark navy gradient, branding blanco + verde
- Dashboard: cards con Boldo radius, iconos navy, quick actions
- Summary Cards: variantes navy/green/cyan/orange
- Transfers: formularios con pill buttons, inputs Boldo
- Profile: avatar navy, security items con bg #F1F1F1
- History: chips con colores Boldo (cyan/green/orange/red)
- Confirm Dialog: iconos con fondos soft Boldo
- Page Header: títulos negros, subtítulos #5B7075

Material 3 Theme:
- Cyan primary palette + Green tertiary
- Pill-shaped buttons, snackbars, chips globales
- Manrope como brand y plain family

https://claude.ai/code/session_01RGKS9XE2UxGP37ACfU3j57